### PR TITLE
Feat: allow containers to ignore cron

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3.9-alpine
 
 ENV IN_DOCKER_CONTAINER true
+ENV EXTERNAL_CRON false
 WORKDIR /app
 COPY . .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM python:3.9-alpine
 
 ENV IN_DOCKER_CONTAINER true
-ENV EXTERNAL_CRON false
 WORKDIR /app
 COPY . .
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ docker run -d --name hcloud-snapshot-as-backup \
 
 Replace `YOUR-API-TOKEN` with your [Hetzner Cloud Console API-Key](#generate-hetzner-cloud-console-api-key).
 
-Optional: add `--env EXTERNAL_CRON=true` to schedule outside of the container, especially using services like [Google Cloud Run jobs](https://cloud.google.com/run/docs/create-jobs) or [Amazon ECS scheduled tasks](https://docs.aws.amazon.com/AmazonECS/latest/userguide/scheduled_tasks.html)
+Optional: use `--env CRON=false` to schedule outside of the container, especially using services like [Google Cloud Run jobs](https://cloud.google.com/run/docs/create-jobs) or [Amazon ECS scheduled tasks](https://docs.aws.amazon.com/AmazonECS/latest/userguide/scheduled_tasks.html)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ docker run -d --name hcloud-snapshot-as-backup \
 
 Replace `YOUR-API-TOKEN` with your [Hetzner Cloud Console API-Key](#generate-hetzner-cloud-console-api-key).
 
+Optional: add `--env EXTERNAL_CRON=true` to schedule outside of the container, especially using services like [Google Cloud Run jobs](https://cloud.google.com/run/docs/create-jobs) or [Amazon ECS scheduled tasks](https://docs.aws.amazon.com/AmazonECS/latest/userguide/scheduled_tasks.html)
+
 ---
 
 ### Installation: With Docker Compose

--- a/README.md
+++ b/README.md
@@ -128,13 +128,15 @@ By default they are named `<server name>-<timestamp>`.
 ### Docker: Specify how often the script should be executed via cron
 If you run the script in Docker, a cron may be specified in the environment variables under `CRON`.  
 The cron is used to define how often and at which times the script should be executed.  
+Optionally, set `CRON` to `false` to disable CronScheduler in the container and schedule outside of the container.
+
 Here you can create a cron: [Cron Generator](https://crontab.guru/#0_1_*_*_*)  
 
 For example:  
 ```
 0 1 * * *
 ```
-This cron executes the script every day at 1am. Optionally, set `CRON` to `false` to disable CronScheduler in the container and schedule outside of the container
+This cron executes the script every day at 1am.
 
 ## About Labels  
 This script works with the powerful Hetzner Labels.  

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ docker run -d --name hcloud-snapshot-as-backup \
 
 Replace `YOUR-API-TOKEN` with your [Hetzner Cloud Console API-Key](#generate-hetzner-cloud-console-api-key).
 
-Optional: use `--env CRON=false` to schedule outside of the container, especially using services like [Google Cloud Run jobs](https://cloud.google.com/run/docs/create-jobs) or [Amazon ECS scheduled tasks](https://docs.aws.amazon.com/AmazonECS/latest/userguide/scheduled_tasks.html)
+Optional: Set `CRON` to `false` to disable CronScheduler in the container and schedule outside of the container, especially for using services like [Google Cloud Run jobs](https://cloud.google.com/run/docs/create-jobs) or [Amazon ECS scheduled tasks](https://docs.aws.amazon.com/AmazonECS/latest/userguide/scheduled_tasks.html)
 
 ---
 
@@ -126,7 +126,7 @@ By default they are named `<server name>-<timestamp>`.
 | %timestamp% | Current timestamp  |
 
 ### Docker: Specify how often the script should be executed via cron
-If you run the script in Docker, a cron must be specified in the environment variables under `CRON`.  
+If you run the script in Docker, a cron may be specified in the environment variables under `CRON`.  
 The cron is used to define how often and at which times the script should be executed.  
 Here you can create a cron: [Cron Generator](https://crontab.guru/#0_1_*_*_*)  
 
@@ -134,7 +134,7 @@ For example:
 ```
 0 1 * * *
 ```
-This cron executes the script every day at 1am.  
+This cron executes the script every day at 1am. Optionally, set `CRON` to `false` to disable CronScheduler in the container and schedule outside of the container
 
 ## About Labels  
 This script works with the powerful Hetzner Labels.  

--- a/snapshot-as-backup.py
+++ b/snapshot-as-backup.py
@@ -153,19 +153,25 @@ if __name__ == '__main__':
         api_token = os.environ.get('API_TOKEN')
         snapshot_name = os.environ.get('SNAPSHOT_NAME', "%name%-%timestamp%")
         keep_last_default = int(os.environ.get('KEEP_LAST', 3))
-        cron_string = os.environ.get('CRON', '0 1 * * *')
-        cron_scheduler = CronScheduler(cron_string)
-
-        print(f"Starting CronScheduler [{cron_string}]...")
-
-        while True:
-            try:
-                if cron_scheduler.time_for_execution():
-                    print("Script is now executed by cron...")
-                    run()
-            except KeyboardInterrupt:
-                sys.exit(0)
-
+        
+        EXTERNAL_CRON = os.environ.get('EXTERNAL_CRON', False)
+        if EXTERNAL_CRON == 'true':
+            run()
+        
+        else:
+            cron_string = os.environ.get('CRON', '0 1 * * *')
+            cron_scheduler = CronScheduler(cron_string)
+            
+            print(f"Starting CronScheduler [{cron_string}]...")
+            
+            while True:
+                try:
+                    if cron_scheduler.time_for_execution():
+                        print("Script is now executed by cron...")
+                        run()
+                except KeyboardInterrupt:
+                    sys.exit(0)
+        
     else:
         with open(os.path.join(os.path.abspath(os.path.dirname(__file__)), "config.json"), "r") as config_file:
             config = json.load(config_file)

--- a/snapshot-as-backup.py
+++ b/snapshot-as-backup.py
@@ -154,8 +154,8 @@ if __name__ == '__main__':
         snapshot_name = os.environ.get('SNAPSHOT_NAME', "%name%-%timestamp%")
         keep_last_default = int(os.environ.get('KEEP_LAST', 3))
         
-        EXTERNAL_CRON = os.environ.get('EXTERNAL_CRON', False)
-        if EXTERNAL_CRON == 'true':
+        CRON = os.environ.get('CRON', '0 1 * * *')
+        if CRON == 'false':
             run()
         
         else:

--- a/snapshot-as-backup.py
+++ b/snapshot-as-backup.py
@@ -160,10 +160,9 @@ if __name__ == '__main__':
             run()
         
         else:
-            cron_scheduler = CronScheduler(cron_string)
-            
             print(f"Starting CronScheduler [{cron_string}]...")
-            
+            cron_scheduler = CronScheduler(cron_string)
+                        
             while True:
                 try:
                     if cron_scheduler.time_for_execution():

--- a/snapshot-as-backup.py
+++ b/snapshot-as-backup.py
@@ -154,12 +154,12 @@ if __name__ == '__main__':
         snapshot_name = os.environ.get('SNAPSHOT_NAME', "%name%-%timestamp%")
         keep_last_default = int(os.environ.get('KEEP_LAST', 3))
         
-        CRON = os.environ.get('CRON', '0 1 * * *')
-        if CRON == 'false':
+        cron_string = os.environ.get('CRON', '0 1 * * *')
+        
+        if cron_string is False or cron_string.lower() == 'false':
             run()
         
         else:
-            cron_string = os.environ.get('CRON', '0 1 * * *')
             cron_scheduler = CronScheduler(cron_string)
             
             print(f"Starting CronScheduler [{cron_string}]...")


### PR DESCRIPTION
Please let me know if this is useful or you'd rather do things differently, but I'd like to use this on a service like [Google Cloud Run](https://cloud.google.com/run/docs/create-jobs) or [Amazon ECS](https://docs.aws.amazon.com/AmazonECS/latest/userguide/scheduled_tasks.html) as a scheduled task, rather than a cron builtin.

As such I've added support for an extra `EXTERNAL_CRON` envvar, defaulting to false in containers, that when true will just run as normal. I don't write much Python so code may be messy/sub-optimal 😅 but can confirm this works as intended, so can just exit once complete and re-run on an external schedule as with 'normal' crontab.

Aside: thanks for the really cool project! I came across this after upgrading OS versions and running a blind `terraform apply` - the image ID discrepancy forced a resource recreate 🙈 and backups are server-scoped, so goodbye data