### PR TITLE
Add changeable label_selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,9 @@ The newest ones are kept and old ones are deleted.
 ### Add label to servers that should be backed up  
 All servers that should be included by the script and automatic snapshot backups should be created must have the label `AUTOBACKUP` with the value `true`.  
 
+### Change default label to something else
+You can change the default label from `AUTOBACKUP` to something else by changing the `label_selector` value in the config. If in a docker environment you can set `--env LABEL_SELECTOR`. When changing the `label_selector`, you must also use this for the `KEEP-LAST` setting. 
+
 ### Choose a name for your snapshots (optional)  
 Specify how you want your snapshots to be named in the environment variables under `SNAPSHOT_NAME` or under `snapshot-name` in the config.  
 By default they are named `<server name>-<timestamp>`.  

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ The newest ones are kept and old ones are deleted.
 All servers that should be included by the script and automatic snapshot backups should be created must have the label `AUTOBACKUP` with the value `true`.  
 
 ### Change default label to something else
-You can change the default label from `AUTOBACKUP` to something else by changing the `label_selector` value in the config. If in a docker environment you can set `--env LABEL_SELECTOR`. When changing the `label_selector`, you must also use this for the `KEEP-LAST` setting. 
+You can change the default label from `AUTOBACKUP` to something else by changing the `label_selector` value in the config. If in a docker environment you can set the `LABEL_SELECTOR` environment variable. When changing the `label_selector`, you must also use this for the `KEEP-LAST` setting. 
 
 ### Choose a name for your snapshots (optional)  
 Specify how you want your snapshots to be named in the environment variables under `SNAPSHOT_NAME` or under `snapshot-name` in the config.  

--- a/config-example.json
+++ b/config-example.json
@@ -1,4 +1,5 @@
 {
+  "label-selector": "AUTOBACKUP",
   "api-token": "",
   "snapshot-name": "%name%-%timestamp%",
   "keep-last": 3

--- a/config-example.json
+++ b/config-example.json
@@ -1,6 +1,6 @@
 {
-  "label-selector": "AUTOBACKUP",
   "api-token": "",
   "snapshot-name": "%name%-%timestamp%",
+  "label-selector": "AUTOBACKUP",
   "keep-last": 3
 }

--- a/snapshot-as-backup.py
+++ b/snapshot-as-backup.py
@@ -152,10 +152,9 @@ if __name__ == '__main__':
     IN_DOCKER_CONTAINER = os.environ.get('IN_DOCKER_CONTAINER', False)
 
     if IN_DOCKER_CONTAINER:
-
-        label_selector = os.environ.get('LABEL_SELECTOR', 'AUTOBACKUP')
         api_token = os.environ.get('API_TOKEN')
         snapshot_name = os.environ.get('SNAPSHOT_NAME', "%name%-%timestamp%")
+        label_selector = os.environ.get('LABEL_SELECTOR', 'AUTOBACKUP')
         keep_last_default = int(os.environ.get('KEEP_LAST', 3))
 
         cron_string = os.environ.get('CRON', '0 1 * * *')

--- a/snapshot-as-backup.py
+++ b/snapshot-as-backup.py
@@ -180,9 +180,9 @@ if __name__ == '__main__':
         with open(os.path.join(os.path.abspath(os.path.dirname(__file__)), "config.json"), "r") as config_file:
             config = json.load(config_file)
 
-        label_selector = config['label-selector']
         api_token = config['api-token']
         snapshot_name = config['snapshot-name']
+        label_selector = config['label-selector']
         keep_last_default = int(config['keep-last'])
 
         run()


### PR DESCRIPTION
This PR is to allow for custom tag to be target-able. This is a solution to a problem of needing to create snapshots at different intervals. 

For example: Some servers might have the **AUTOBACKUP_DAILY** and **AUTOBACKUP_WEEKLY** and I would have 2 separate cron jobs running at those intervals which would each target the correct tag.