### PR TITLE
Exit with failure if any API request fails

### DIFF
--- a/snapshot-as-backup.py
+++ b/snapshot-as-backup.py
@@ -16,8 +16,8 @@ headers = {}
 servers = {}
 servers_keep_last = {}
 snapshot_list = {}
-
 exit_code = 0
+
 
 def get_servers(page=1):
     global exit_code


### PR DESCRIPTION
When using this script in some sort of external scheduler (eg Kubernetes CronJob), the scheduler should know if anything went wrong - exit the script with code 1